### PR TITLE
Fix Non-Idempotent-Outcome flaky test: test_cmd_path

### DIFF
--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -352,13 +352,17 @@ class TestWhich:
         assert which(mycmd) == mycmd
 
     def test_cmd_path(self, tmpdir, mycmd):
-        path = str(tmpdir)
-        assert which('mycmd') is None
-        assert which('mycmd', path=path) == mycmd
+        original_path = os.environ['PATH']
+        try:
+            path = str(tmpdir)
+            assert which('mycmd') is None
+            assert which('mycmd', path=path) == mycmd
 
-        os.environ['PATH'] = path + os.pathsep + \
-            os.environ.get('PATH', os.defpath)
-        assert which('mycmd') == mycmd
+            os.environ['PATH'] = path + os.pathsep + \
+                os.environ.get('PATH', os.defpath)
+            assert which('mycmd') == mycmd
+        finally:
+            os.environ['PATH'] = original_path
 
 
 @pytest.mark.skipif(not WINDOWS, reason='Not support non Windows')


### PR DESCRIPTION
Ran pytest --flake-finder test_system.py and notice test_cmd_path to be a Non-Idempotent-Outcome test which the test pass in the first run but fail in the second. The fix ensures that the original PATH is stored before modification and restored after the test completes.